### PR TITLE
Update NanoOpt for recent mBuild changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,36 @@
 
 NanoOpt is centered around the [mBuild package](https://github.com/mosdef-hub/mbuild) which is easiest to install using the Anaconda package manager. The recommended installation instructions are as follows:
 
-Install mBuild using conda:
-```
-conda install -c omnia -c mosdef mbuild
-```
+#### NOTE
 
-NanoOpt can then be cloned and installed via:
-```
+For the version of mbuild used in this paper and study, use `environment.yml`.
+For a newer version of the packages with improved mBuild features, use `environment-dev.yml`.
+
+1. Clone NanoOpt:
+```sh
 git clone https://github.com/summeraz/nanoparticle_optimization
 cd nanoparticle_optimization
+```
+
+2. Determine what version you want to use:
+Refer to the note above
+
+* If you want to emulate the study and paper:
+```
+git checkout bdaa8b8
+conda env create -f environment.yml
+conda activate nanoopt-binder
 pip install .
 ```
+
+* If you want to use newer package versions
+```
+conda env create -f environment.yml
+conda activate nanoopt-binder
+pip install .
+```
+
+
 
 # Tutorials
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -2,14 +2,12 @@ name: nanoopt-binder
 
 channels:
   - conda-forge
-  - defaults
-  - mosdef
-  - omnia
 
 dependencies:
-  - python=3.5
+  - python>=3.5
   - numpy
   - scipy
   - numba
   - mbuild
+  - py3dmol
   - nglview

--- a/nanoparticle_optimization/lib/nanoparticles/AA_nano.py
+++ b/nanoparticle_optimization/lib/nanoparticles/AA_nano.py
@@ -21,7 +21,8 @@ class AA_nano(mb.Compound):
 
         O_buffer = 0.275
         # Replicate the bulk silica box if necessary
-        rep = math.ceil(((radius+O_buffer)/single.periodicity[0])*2.0)
+        # rep = math.ceil(((radius+O_buffer)/single.periodicity[0])*2.0)
+        rep = math.ceil(((radius + O_buffer) / single.box.Lx) * 2.0 )
         rep = int(rep)
         bulk = mb.recipes.TiledCompound(tile=single,n_tiles=np.array([rep,rep,rep]),name="bulk_silica")
         bulk_name = []
@@ -29,7 +30,7 @@ class AA_nano(mb.Compound):
         for particle in bulk.particles():
             bulk_name.append(particle.name)
             bulk_pos.append(particle.pos)
-        bulk_center = [bulk.periodicity[i]/2.0 for i in range(3)]
+        bulk_center = [bulk.box.lengths[i]/2.0 for i in range(3)]
         dists = distance.cdist(bulk_pos,[bulk_center],'euclidean')
         types = {'1':'Si','2':'O'}
         if O_layer:

--- a/nanoparticle_optimization/lib/nanoparticles/silica.py
+++ b/nanoparticle_optimization/lib/nanoparticles/silica.py
@@ -8,7 +8,8 @@ class Silica(mb.Compound):
 
         mb.load('bulk_silica.pdb', compound=self,
                 relative_to_module=self.__module__)
-        self.periodicity = np.array([5, 5, 5])
+        self.box = mb.Box([5, 5, 5])
+        self.periodicity = [True, True, True]
 
 if __name__ == "__main__":
     s = Silica()


### PR DESCRIPTION
Currently, `NanoOpt` has not been updated to support the major box and
periodicity overhaul that occured with newer versions of mBuild.

This PR employs those changes, while also updating the README so users
who want to use the version that was used during the publication should
be able to do so as well. They just need to use a version at a specific
git commit, which has been added to the readme.